### PR TITLE
works with newer docker version

### DIFF
--- a/distrobox.go
+++ b/distrobox.go
@@ -24,6 +24,7 @@ type distroboxItem struct {
 type OCICmdOutput struct {
 	Id     string `json:"ID"`
 	Image  string `json:"Image"`
+	Labels string `json:"Labels"`
 	Mounts string `json:"Mounts"`
 	Names  string `json:"Names"`
 	Status string `json:"Status"`
@@ -128,15 +129,22 @@ func getDistroboxItems() (items []distroboxItem) {
 
 	if len(items) == 0 {
 		for _, jsonElem := range outputs {
-			log.Printf("%+v\n", jsonElem)
-			box := distroboxItem{
-				id:     jsonElem.Id[:12],
-				name:   jsonElem.Names,
-				status: jsonElem.Status,
-				image:  jsonElem.Image,
-			}
+			labels := strings.Split(jsonElem.Labels, ",")
+			for _, label := range labels {
+				if label == "manager=distrobox" {
+					log.Printf("%+v\n", jsonElem)
+					box := distroboxItem{
+						id:     jsonElem.Id[:12],
+						name:   jsonElem.Names,
+						status: jsonElem.Status,
+						image:  jsonElem.Image,
+					}
 
-			items = append(items, box)
+					items = append(items, box)
+
+					break
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Also works now on nixos with the non hardcoded /usr/bin

It failed to parse the docker ps -a --format json output because of the schema change with this docker version.

```
$ docker version
Client:
 Version:           24.0.9
 API version:       1.43
 Go version:        go1.22.3
 Git commit:        v24.0.9
 Built:             Thu Jan  1 00:00:00 1970
 OS/Arch:           linux/amd64
 Context:           default

Server:
 Engine:
  Version:          24.0.9
  API version:      1.43 (minimum version 1.12)
  Go version:       go1.22.3
  Git commit:       v24.0.9
  Built:            Tue Jan  1 00:00:00 1980
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.7.16
  GitCommit:        v1.7.16
 runc:
  Version:          1.1.12
  GitCommit:
 docker-init:
  Version:          0.19.0
  GitCommit:
=
```